### PR TITLE
Tested and extended to GNOME 48/49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Version 4.1
+
+- Extended support for GNOME Shell 48 and 49.
+  - Tested on GNOME Shell 48/49 (Fedora 42/43) with no issues.
+  - Omitted GNOME Shell 47 as it was not tested.

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,9 @@
   "description": "Display all tray icons in grayscale",
   "version": 4,
   "shell-version": [
-    "46"
+    "46",
+    "48",
+    "49"
   ],
   "url": "https://github.com/CR1337/desaturated-tray-icons"
 }


### PR DESCRIPTION
## Context

Put simply, to extend support for GNOME versions being used in distribution (e.g. Fedora 42/43). The current version of the extension only has support for GNOME version 46, which is fairly old now.

## Description

- Add GNOME versions to the manifest.
- Test the extension in the corresponding environment.
- Document any issues if found.
- Add version minor.
- Add change log.

## Additional information

The current code base does work, but it seems isn't future proof. `Clutter` was marked as deprecated and so use of it is on borrowed time. However is has not been phased out. `St` is built on top of `Clutter` but does not seem to have an effect API.