### PR TITLE
Fix: Mutter log warning spam on window/overview transition

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,43 +1,54 @@
-import Clutter from 'gi://Clutter';
-import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import Clutter from "gi://Clutter";
+import * as Main from "resource:///org/gnome/shell/ui/main.js";
 
 export default class Extension {
-    constructor() {
-    }
+  constructor() {}
 
-    enable() {
-        this._child_added_signal_id = Main.panel._rightBox.connect(
-            'child-added', this._child_added_event_handler
-        )
-        this._add_effects();
-    }
+  enable() {
+    this._child_added_signal_id = Main.panel._rightBox.connect(
+      "child-added",
+      this._child_added_event_handler,
+    );
+    this._add_effects();
+  }
 
-    disable() {
-        Main.panel._rightBox.disconnect(this._child_added_signal_id);
-        this._remove_effects();
-    }
+  disable() {
+    Main.panel._rightBox.disconnect(this._child_added_signal_id);
+    this._remove_effects();
+  }
 
-    _child_added_event_handler(_, child) {
+  _dimension_check(child) {
+    if (child.width > 0 && child.height > 0) return true;
+    return false;
+  }
+
+  _child_added_event_handler(_, child) {
+    if (this._dimension_check(child)) {
+      child.add_effect(new Clutter.DesaturateEffect());
+    }
+  }
+
+  _get_tray() {
+    return Main.panel._rightBox.get_children();
+  }
+
+  _add_effects() {
+    for (let child of this._get_tray()) {
+      if (this._dimension_check(child)) {
         child.add_effect(new Clutter.DesaturateEffect());
+      }
     }
+  }
 
-    _get_tray() {
-        return Main.panel._rightBox.get_children();
-    }
-
-    _add_effects() {
-        for (let child of this._get_tray()) {
-            child.add_effect(new Clutter.DesaturateEffect());
+  _remove_effects() {
+    for (let child of this._get_tray()) {
+      for (let effect of child.get_effects()) {
+        if (effect instanceof Clutter.DesaturateEffect) {
+          if (this._dimension_check(child)) {
+            child.remove_effect(effect);
+          }
         }
+      }
     }
-
-    _remove_effects() {
-        for (let child of this._get_tray()) {
-            for (let effect of child.get_effects()) {
-                if (effect instanceof Clutter.DesaturateEffect) {
-                    child.remove_effect(effect);
-                }
-            }
-        }
-    }
+  }
 }


### PR DESCRIPTION
## Context

The following warning kept showing up in the journal (using `journalctl -f`) for `gnome-shell`:

```
gnome-shell[5283]: cogl_framebuffer_set_viewport: assertion 'width > 0 && height > 0' failed
```

Whilst this seems to be happening with a number of GNOME extensions, a large amount of the output attributes to this extension.

## Investigation

Upon observing this behaviour, I went to report it as an issue but found the issue https://github.com/CR1337/desaturated-tray-icons/issues/5 had already been reported, but it had gone unresolved due to lack of replication.

It was found that this issue seems to relate to desktop environments using Wayland/Mutter, and ultimately is not an error but a warning - so nothing to be overly concerned about.

The warning comes from Clutter/COGL, the graphics layer used by GNOME Shell. It means something (usually an extension) is trying to draw to a frame buffer with a width or height of 0, which is invalid.

### Why It Keeps Popping Up

- The extension tries to modify a tray icon (child)
- The icon has not been fully initialised yet, during redraws
- GNOME reports the traversed icon size as 0x0
- The extension still attempts to render it, producing an assertion error

## Solution

- Check target geometry before applying any process
  - If the geometry is zero: do nothing
  - Otherwise, apply the intended effect

## Description

- commit: geometry check to mitigate mutter render warning
- test (this branch): PASS (Fedora 43, GNOME 49, Wayland/Mutter)
  - enable extension
  - trigger warning - window/overview switch
  - journal warnings; NONE
- regression test (main branch): FAIL (Fedora 43, GNOME 49, Wayland/Mutter)
  - enable extension
  - trigger warning - window/overview switch
  - journal warnings; EVIDENT

## Additional information

Issue can be closed if this update proves to be sufficient.
